### PR TITLE
Fix allow-once checks to handle whitespace before braces

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -206,11 +206,11 @@ function validateTextDocument(textDocument: TextDocument) {
 
   getBracketsDiagnostics(textWithoutComments, textDocument, diagnostics);
 
-  const allowOncePipelinesBlock = /pipeline(| ){/g;
-  // let allowOnceStagesBlock = /stages(| ){/g;
-  // let allowOnceOptionsBlock = /options(| ){/g;
-  const allowOnceParametersBlock = /parameters(| ){/g;
-  const allowOnceTriggersBlock = /triggers(| ){/g;
+  const allowOncePipelinesBlock = /pipeline\s*{/g;
+  // let allowOnceStagesBlock = /stages\s*{/g;
+  // let allowOnceOptionsBlock = /options\s*{/g;
+  const allowOnceParametersBlock = /parameters\s*{/g;
+  const allowOnceTriggersBlock = /triggers\s*{/g;
 
   getAllowOnceDiagnostics(
     allowOncePipelinesBlock,


### PR DESCRIPTION
## Summary
- allow allow-once regex checks to detect keywords when the opening brace is separated by arbitrary whitespace

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8998aecfc8330802325a46a2cf2ed